### PR TITLE
Add patch to assume the rollup type to save metadata operations

### DIFF
--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
@@ -139,7 +139,7 @@ public enum CoreConfig implements ConfigDefaults {
     STRING_METRICS_DROPPED("false"),
     TENANTIDS_TO_KEEP(""),
 
-    APPLY_ROLLUP_TYPE_PATCH("false");
+    BYPASS_ROLLUP_TYPE_CACHE("false");
 
     static {
         Configuration.getInstance().loadDefaults(CoreConfig.values());

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/RollupRunnable.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/RollupRunnable.java
@@ -97,7 +97,7 @@ public class RollupRunnable implements Runnable {
             Points input;
             Rollup rollup = null;
             RollupType rollupType;
-            if (Configuration.getInstance().getBooleanProperty(CoreConfig.APPLY_ROLLUP_TYPE_PATCH)) {
+            if (Configuration.getInstance().getBooleanProperty(CoreConfig.BYPASS_ROLLUP_TYPE_CACHE)) {
                 rollupType = RollupType.BF_BASIC;
             } else {
                 rollupType = RollupType.fromString(rollupTypeCache.get(


### PR DESCRIPTION
Currently, metadata reads seem to have huge impact on the performance of the cluster, especially during startup, when the rollup type gets populated in the cache. We need the rollup type only for deciding when to do basic rollups vs pre-aggregated rollup types. But right now we are more concerned about basic rollups for monitoring rather than other pre-aggregated rollup types, so we can assume `BF_BASIC` for all rollups and ignore these pre-aggregated metrics for now.
